### PR TITLE
Localize HD Options Menu Entry

### DIFF
--- a/menudef.txt
+++ b/menudef.txt
@@ -22,7 +22,7 @@ ListMenu "MainMenu"{
 	IfGame(Doom,Strife,Chex){
 		PatchItem "M_NGAME","n","HDNewGameLoadoutMenu2"
 //			TextItem "HD Loadouts","o","HDLoadoutMenu2"
-			TextItem "HD Options","o","HDOptionsMenu"
+			TextItem "$MNU_HDOPTIONS","o","HDOptionsMenu"
 //			TextItem "HD Controls","o","HDControlsMenu"
 		ifOption(SwapMenu){
 			PatchItem "M_LOADG","l","LoadGameMenu"


### PR DESCRIPTION
This will need the [appropriate PR](https://codeberg.org/mc776/HideousDestructor/pulls/246) from HDest itself merged in first, unless you'd rather have the entry redefined just in case?